### PR TITLE
Add Wooting Two HE (ARM) support

### DIFF
--- a/src/main/java/org/voegl/analogkey4j/plugins/wooting/WootingDevice.java
+++ b/src/main/java/org/voegl/analogkey4j/plugins/wooting/WootingDevice.java
@@ -18,6 +18,7 @@ public class WootingDevice extends AnalogKeyboardDevice {
       Set.of(
           new SimpleAnalogKeyboard("Wooting 60HE", 0x31e3, 0x1312, 0xffffff54),
           new SimpleAnalogKeyboard("Wooting 80HE", 0x31e3, 0x1402, 0xffffff54),
+          new SimpleAnalogKeyboard("Wooting Two HE (ARM)", 0x31e3, 0x1232, 0xffffff54),
           new SimpleAnalogKeyboard("Wooting Two Legacy", 0x03eb, 0xff02, 0xffffff54),
           new SimpleAnalogKeyboard("Wooting One Legacy", 0x03eb, 0xff01, 0xffffff54));
   private static final HidParser PARSER = new HidParser(HidKeyMap.getInstance());


### PR DESCRIPTION
seems to work fine
I found more devices [here](https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/fix_readme_images/Controllers/WootingKeyboardController/WootingKeyboardControllerDetect.cpp) if you want to add them